### PR TITLE
Attempt to create java.io.tmpdir in case it does not exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 *.iml
 *.orig
 /.classpath
+tests/ci/cdk/.idea
+tests/ci/cdk/venv

--- a/src/com/amazon/corretto/crypto/provider/Loader.java
+++ b/src/com/amazon/corretto/crypto/provider/Loader.java
@@ -412,9 +412,6 @@ final class Loader {
      */
     private static synchronized Path createPrivateTmpDir(final String prefix) throws IOException {
         final Path systemTempDir = Paths.get(System.getProperty("java.io.tmpdir"));
-        if (!Files.isDirectory(systemTempDir)) {
-            throw new AssertionError("java.io.tmpdir is not valid: " + systemTempDir);
-        }
 
         final int RETRY_LIMIT = 10;
         int attempt = 0;
@@ -436,7 +433,7 @@ final class Loader {
 
                 final Path privateDirFullPath = systemTempDir.resolve(privateTempDir.toString());
 
-                final Path result = Files.createDirectory(privateDirFullPath, SELF_OWNER_FILE_PERMISSIONS);
+                final Path result = Files.createDirectories(privateDirFullPath, SELF_OWNER_FILE_PERMISSIONS);
                 if (DebugFlag.VERBOSELOGS.isEnabled()) {
                     LOG.log(Level.FINE, "Created temporary library directory");
                 }


### PR DESCRIPTION
*Create temp directory*

The temporary directory used by ACCP is passed via `java.io.tmpdir`. There are cases where another operation may delete this folder before ACCP has a chance to use it. We try to create that directory in case it has been deleted.

The [Files.createDirectories](https://docs.oracle.com/javase/8/docs/api/java/nio/file/Files.html#createDirectories-java.nio.file.Path-java.nio.file.attribute.FileAttribute...-) does not fail in case the directories already exist.
