### PR TITLE
Avoid running CI tasks on v1 branch

### DIFF
--- a/tests/ci/cdk/cdk/accp_github_ci_stack.py
+++ b/tests/ci/cdk/cdk/accp_github_ci_stack.py
@@ -4,7 +4,7 @@
 from aws_cdk import core, aws_codebuild as codebuild, aws_iam as iam
 from util.ecr_util import ecr_arn
 from util.iam_policies import code_build_batch_policy_in_json
-from util.metadata import AWS_ACCOUNT, AWS_REGION, GITHUB_REPO_OWNER, GITHUB_REPO_NAME
+from util.metadata import GITHUB_REPO_OWNER, GITHUB_REPO_NAME, GITHUB_BRANCH_EXCLUDE_CI
 from util.yml_loader import YmlLoader
 
 
@@ -27,11 +27,11 @@ class ACCPGitHubCIStack(core.Stack):
             fetch_submodules=True,
             webhook_filters=[
                 codebuild.FilterGroup.in_event_of(
-                    codebuild.EventAction.PUSH,
                     codebuild.EventAction.PULL_REQUEST_MERGED,
                     codebuild.EventAction.PULL_REQUEST_CREATED,
                     codebuild.EventAction.PULL_REQUEST_UPDATED,
                     codebuild.EventAction.PULL_REQUEST_REOPENED)
+                .and_base_branch_is_not(GITHUB_BRANCH_EXCLUDE_CI)
             ],
             webhook_triggers_batch_build=True)
 

--- a/tests/ci/cdk/util/metadata.py
+++ b/tests/ci/cdk/util/metadata.py
@@ -17,6 +17,7 @@ WINDOWS_X86_ECR_REPO = EnvUtil.get("ECR_WINDOWS_X86_REPO_NAME", "accp-docker-ima
 GITHUB_REPO_OWNER = EnvUtil.get("GITHUB_REPO_OWNER", "corretto")
 GITHUB_REPO_NAME = EnvUtil.get("GITHUB_REPO_NAME", "amazon-corretto-crypto-provider")
 GITHUB_SOURCE_VERSION = EnvUtil.get("GITHUB_SOURCE_VERSION", "develop")
+GITHUB_BRANCH_EXCLUDE_CI = EnvUtil.get("GITHUB_BRANCH_EXCLUDE_CI", "v1")
 
 # Used when AWS CDK defines resources for Windows docker image build.
 S3_BUCKET_NAME = EnvUtil.get("S3_FOR_WIN_DOCKER_IMG_BUILD", "accp-windows-docker-image-build")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* The CI tasks for V2 are not compatibile with ACCP 1.x
* The CI tasks for ACCP 1.x would be added to its pipeline


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
