### PR TITLE
Update scripts for 1.6.2 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -590,7 +590,24 @@ add_custom_command(
 add_custom_target(tests-jar DEPENDS ${TESTS_JAR})
 set_property(TARGET tests-jar PROPERTY JAR_FILE ${TESTS_JAR})
 
+# These flags are necessary in Java17+ in order for certain unit tests to
+# perform deep reflection on nonpublic members
+
+if (Java_VERSION_MAJOR VERSION_GREATER_EQUAL 17)
+    message(STATUS "Adding needed flags for deep reflection")
+    set(TEST_ADD_OPENS
+        --add-opens java.base/javax.crypto=ALL-UNNAMED
+        --add-opens java.base/java.lang.invoke=ALL-UNNAMED
+        --add-opens java.base/java.security=ALL-UNNAMED
+        --add-opens java.base/sun.security.util=ALL-UNNAMED
+        --add-exports jdk.crypto.ec/sun.security.ec=java.base
+        )
+else()
+    message(STATUS "Not adding needed flags for deep reflection")
+endif()
+
 set(TEST_RUNNER_ARGUMENTS
+    ${TEST_ADD_OPENS}
     -javaagent:${JACOCO_AGENT_JAR}=destfile=coverage/jacoco.exec,classdumpdir=coverage/classes
     -Djava.library.path=$<TARGET_FILE_DIR:amazonCorrettoCryptoProvider>
     -Dcom.amazon.corretto.crypto.provider.inTestSuite=hunter2

--- a/build.gradle
+++ b/build.gradle
@@ -9,9 +9,9 @@ plugins {
 }
 
 group = 'software.amazon.cryptools'
-version = '1.6.1'
+version = '1.6.2'
 
-def openssl_version = '1.1.1j'
+def openssl_version = '1.1.1t'
 def opensslSrcPath = "${buildDir}/openssl/openssl-${openssl_version}"
 
 configurations {
@@ -55,8 +55,8 @@ dependencies {
 
     testDep 'org.junit.jupiter:junit-jupiter:5.6.2'
     testDep 'org.junit.vintage:junit-vintage-engine:5.6.2'
-    testDep 'org.bouncycastle:bcprov-debug-jdk15on:1.65'
-    testDep 'org.bouncycastle:bcpkix-jdk15on:1.65'
+    testDep 'org.bouncycastle:bcprov-debug-jdk15on:1.69'
+    testDep 'org.bouncycastle:bcpkix-jdk15on:1.69'
     testDep 'commons-codec:commons-codec:1.12'
     testDep 'org.hamcrest:hamcrest:2.1'
     testDep 'org.jacoco:org.jacoco.core:0.8.3'
@@ -138,18 +138,19 @@ task executeCmake(type: Exec) {
     workingDir "${buildDir}/cmake"
     def prebuiltJar = null
     if (project.hasProperty('stagingUrl')) {
+        println "Using stagingUrl: ${stagingUrl}"
         mkdir "${buildDir}/tmp"
         exec {
             workingDir "${buildDir}/tmp"
-            commandLine 'wget', "${stagingUrl}/software/amazon/cryptools/${project.name}/${stagingVersion}/${project.name}-${stagingVersion}-linux-x86_64.jar"
+            commandLine 'wget', "${stagingUrl}/software/amazon/cryptools/${project.name}/${version}/${project.name}-${version}-linux-x86_64.jar"
         }
-        prebuiltJar = "${buildDir}/tmp/${project.name}-${stagingVersion}-linux-x86_64.jar"
+        prebuiltJar = "${buildDir}/tmp/${project.name}-${version}-linux-x86_64.jar"
     } else if (System.properties['prebuiltJar'] != null) {
         prebuiltJar = "${projectDir}/" + System.properties['prebuiltJar']
     }
 
-    executable 'cmake'
-    args 'cmake', "-DTEST_CLASSPATH=${configurations.testDep.asPath}", "-DJACOCO_AGENT_JAR=${configurations.jacocoAgent.singleFile}"
+    executable 'cmake3'
+    args "-DTEST_CLASSPATH=${configurations.testDep.asPath}", "-DJACOCO_AGENT_JAR=${configurations.jacocoAgent.singleFile}"
     args "-DOPENSSL_ROOT_DIR=${buildDir}/openssl/bin", '-DCMAKE_BUILD_TYPE=Release', '-DPROVIDER_VERSION_STRING=' + version
     args "-DTEST_RUNNER_JAR=${configurations.testRunner.singleFile}"
 
@@ -303,7 +304,7 @@ task coverage_cmake(type: Exec) {
         mkdir "${buildDir}/cmake-coverage"
     }
     workingDir "${buildDir}/cmake-coverage"
-    executable 'cmake'
+    executable 'cmake3'
     args "-DTEST_CLASSPATH=${configurations.testDep.asPath}"
     args "-DJACOCO_AGENT_JAR=${configurations.jacocoAgent.singleFile}"
     args "-DOPENSSL_ROOT_DIR=${buildDir}/openssl/bin"
@@ -381,7 +382,8 @@ task overkill {
 }
 
 
-if (project.hasProperty('mavenUser') && project.hasProperty('jcecertAlias')) {
+// Avoid configuring publish related tasks when the Jar is provided
+if (!project.hasProperty('stagingUrl') && project.hasProperty('mavenUser') && project.hasProperty('jcecertAlias')) {
     publishing {
         publications {
             mavenJava(MavenPublication) {
@@ -430,19 +432,6 @@ if (project.hasProperty('mavenUser') && project.hasProperty('jcecertAlias')) {
     signing {
         sign publishing.publications.mavenJava
     }
-} else {
-    task publish(overwrite: true) {
-        doFirst {
-            ant.fail('Insufficient configuration for publishing')
-        }
-    }
-
-    task sign(overwrite: true) {
-        doFirst {
-            ant.fail('Insufficient configuration for signing')
-        }
-    }
-
 }
 
 task clean(overwrite: true, type: Delete) {

--- a/docker/Centos6ReleaseTest.Dockerfile
+++ b/docker/Centos6ReleaseTest.Dockerfile
@@ -1,0 +1,29 @@
+FROM public.ecr.aws/docker/library/centos:centos6
+
+RUN mkdir -p /var/cache/yum/x86_64/6/base
+RUN mkdir -p /var/cache/yum/x86_64/6/extras
+RUN mkdir -p /var/cache/yum/x86_64/6/updates
+RUN mkdir -p /var/cache/yum/x86_64/6/centos-sclo-rh
+RUN mkdir -p /var/cache/yum/x86_64/6/centos-sclo-sclo
+
+RUN echo "https://vault.centos.org/6.10/os/x86_64/" > /var/cache/yum/x86_64/6/base/mirrorlist.txt
+RUN echo "http://vault.centos.org/6.10/extras/x86_64/" > /var/cache/yum/x86_64/6/extras/mirrorlist.txt
+RUN echo "http://vault.centos.org/6.10/updates/x86_64/" > /var/cache/yum/x86_64/6/updates/mirrorlist.txt
+RUN echo "http://vault.centos.org/6.10/sclo/x86_64/rh" > /var/cache/yum/x86_64/6/centos-sclo-rh/mirrorlist.txt
+RUN echo "http://vault.centos.org/6.10/sclo/x86_64/sclo" > /var/cache/yum/x86_64/6/centos-sclo-sclo/mirrorlist.txt
+
+RUN yum -y update
+RUN yum -y install centos-release-scl
+RUN yum -y install devtoolset-7-gcc-c++ gsl wget perl patch
+
+RUN curl -L -O https://github.com/Kitware/CMake/releases/download/v3.14.3/cmake-3.14.3.tar.gz
+RUN tar xzf cmake-3.14.3.tar.gz
+RUN (cd cmake-3.14.3 && scl enable devtoolset-7 ./bootstrap && scl enable devtoolset-7 gmake && gmake install)
+
+RUN ln -s /usr/local/bin/cmake /usr/local/bin/cmake3
+
+RUN curl -L -O https://downloads.sourceforge.net/ltp/lcov-1.14-1.noarch.rpm
+
+RUN curl -L -O https://d3pxv6yz143wms.cloudfront.net/11.0.3.7.1/java-11-amazon-corretto-devel-11.0.3.7-1.x86_64.rpm
+
+RUN rpm -i java-11-amazon-corretto-devel-11.0.3.7-1.x86_64.rpm

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/openssl.sha256
+++ b/openssl.sha256
@@ -1,1 +1,1 @@
-aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf  openssl-1.1.1j.tar.gz
+8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b  openssl-1.1.1t.tar.gz


### PR DESCRIPTION
*Description of changes:*

+ Use OpenSSL 1.1.1t
+ Update BC version for testing
+ Avoid integration failure for expired certs when connecting to external URLs
+ Remove dependency on stagingVersion
+ Add Dockerfile used to create CentOS6 image for testing
+ Update Gradle version to be compatible with JDK 17

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
